### PR TITLE
fix: update the delete endpoint

### DIFF
--- a/Library.WebApi/Controllers/BookController.cs
+++ b/Library.WebApi/Controllers/BookController.cs
@@ -39,9 +39,10 @@ namespace Library.WebApi.Controllers
             return Ok(response);
         }
 
-        [HttpDelete]
-        public async Task<ActionResult<DeleteBookResponse>> Delete(DeleteBookRequest request, CancellationToken cancellationToken)
+        [HttpDelete("{id:guid}")]
+        public async Task<ActionResult<DeleteBookResponse>> Delete(Guid id, CancellationToken cancellationToken)
         {
+            DeleteBookRequest request = new DeleteBookRequest(id);
             var response = await _mediator.Send(request, cancellationToken);
             return Ok(response);
         }


### PR DESCRIPTION
Delete endpoint now pull the targeted entity's GUID from the request URL, rather than being supplied in a body. 